### PR TITLE
Fix extraction code failure by updating it for archiver 2.0 API

### DIFF
--- a/ghg.go
+++ b/ghg.go
@@ -177,10 +177,10 @@ func progbar(r io.Reader, size int64) io.Reader {
 func extract(src, dest string) error {
 	base := filepath.Base(src)
 	if strings.HasSuffix(base, ".zip") {
-		return archiver.Unzip(src, dest)
+		return archiver.Zip.Open(src, dest)
 	}
 	if strings.HasSuffix(base, ".tar.gz") || strings.HasSuffix(base, ".tgz") {
-		return archiver.UntarGz(src, dest)
+		return archiver.TarGz.Open(src, dest)
 	}
 	return fmt.Errorf("failed to extract file: %s", src)
 }


### PR DESCRIPTION
When I try to install ghg, I got following error.

```
$ go get github.com/Songmu/ghg/cmd/ghg
# github.com/Songmu/ghg
../go/src/github.com/Songmu/ghg/ghg.go:180: undefined: archiver.Unzip
../go/src/github.com/Songmu/ghg/ghg.go:183: undefined: archiver.UntarGz
```

It looks because of the "mholt/archiver" API changed in 2.0.
https://github.com/mholt/archiver/releases/tag/v2.0

This PR is fix for #5.