### PR TITLE
Fix rename error that occurs if the target is a naked binary

### DIFF
--- a/ghg.go
+++ b/ghg.go
@@ -108,6 +108,9 @@ func (gh *ghg) install(url string) error {
 	tmpdir := filepath.Dir(archivePath)
 	defer os.RemoveAll(tmpdir)
 
+	bin := gh.getBinDir()
+	os.MkdirAll(bin, 0755)
+
 	if !archiveReg.MatchString(url) {
 		_, repo, _, _ := getOwnerRepoAndTag(gh.target)
 		name := lcs(repo, filepath.Base(archivePath))
@@ -128,9 +131,6 @@ func (gh *ghg) install(url string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to extract")
 	}
-
-	bin := gh.getBinDir()
-	os.MkdirAll(bin, 0755)
 
 	err = gh.pickupExecutable(workDir)
 	if err != nil {


### PR DESCRIPTION
# Problem

`ghg get` gets the following error if ghg bin directory doesn't exist and the installation target is a naked binary.

```
% rm -fr /Users/y_uuki/.ghg/bin
% ghg get yuuki/grabeni
fetch the GitHub release for yuuki/grabeni
install yuuki/grabeni version: v0.4.2
download https://github.com/yuuki/grabeni/releases/download/v0.4.2/grabeni_darwin_amd64
[======================================] 17.6 MB/17.6 MB
install grabeni
rename /Users/y_uuki/.ghg/tmp/337788732/grabeni_darwin_amd64 /Users/y_uuki/.ghg/bin/grabeni: no such file or directory
```

# Cause & Fix

The code path for naked binary don't create bin directory, so that moving the download file to bin directory fails.

```
% rm -fr /Users/y_uuki/.ghg/bin
% ./ghg get -u yuuki/grabeni
fetch the GitHub release for yuuki/grabeni
install yuuki/grabeni version: v0.4.2
download https://github.com/yuuki/grabeni/releases/download/v0.4.2/grabeni_darwin_amd64
[======================================] 17.6 MB/17.6 MB
/Users/y_uuki/.ghg/bin/grabeni exists. overwrite it
install grabeni
download https://github.com/yuuki/grabeni/releases/download/v0.4.2/grabeni_darwin_amd64.zip
[======================================] 4.44 MB/4.44 MB
extract grabeni_darwin_amd64.zip
/Users/y_uuki/.ghg/bin/grabeni exists. overwrite it
install grabeni
done!
```

# Question

How about testing for that problem?
It seems good to delete bin directory before testing naked binary, but cleaning process is implemented by TestMain. 
Which should we take the following choices? 

- Clean bin directory each TableDrivenTests iteration
- or separate TableDrivenTests iterations to two test functions.
- or simply add another test function for that problem.